### PR TITLE
Encode e-mail addresses on URL creation.

### DIFF
--- a/src/IPQualityScore/Model/EmailVerification.php
+++ b/src/IPQualityScore/Model/EmailVerification.php
@@ -82,7 +82,7 @@ class EmailVerification
         ]);
 
         $request = $this->IPQualityScore->client
-            ->setEndpoint(sprintf(IPQualityScore::API_URL . self::API_ENDPOINT, $this->IPQualityScore->apiKey, $email, $parameters))
+            ->setEndpoint(sprintf(IPQualityScore::API_URL . self::API_ENDPOINT, $this->IPQualityScore->apiKey, urlencode($email), $parameters))
             ->setMethod('GET')
             ->performHttpRequest();
 


### PR DESCRIPTION
Currently, the library requires the developer to encode the e-mail address when requesting verification data:
`(new IPQualityScore(...))->emailVerification->getResponse(urlencode($email));`
Addresses not being encoded can lead to 404 responses from IPQualityScore (e.g., `na$tyexample@gmail.com`).

In my opinion, it is up to the library to create valid requests, so the proposed change here takes care of address encoding within the `getResponse()` method.

Using `urlencode` when building the URL is the recommended way to build verification requests, see PHP example at https://www.ipqualityscore.com/documentation/email-validation/overview.